### PR TITLE
fix: 🐛 prevent uncaught TypeError when no react dev tools

### DIFF
--- a/src/devtools.ts
+++ b/src/devtools.ts
@@ -24,7 +24,7 @@ export function reactDevtoolsPlugin({
             {
               injectTo: "body",
               tag: `script`,
-              children: `window.__REACT_DEVTOOLS_GLOBAL_HOOK__.inject = function () {};`,
+              children: `if (typeof window.__REACT_DEVTOOLS_GLOBAL_HOOK__ === 'object') { window.__REACT_DEVTOOLS_GLOBAL_HOOK__.inject = function () {};};`,
             },
           ],
         };


### PR DESCRIPTION
🏁 Closes: #6